### PR TITLE
3 - Codefix provider do not update invocation

### DIFF
--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer15.Vsix/source.extension.vsixmanifest
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer15.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="MalikP.Analyzers.AsyncMethodAnalyzer.E522C155-0DAB-4279-946A-DD03A34258F4" Version="0.3.16" Language="en-US" Publisher="MalikP. (Peter Malik)"/>
+        <Identity Id="MalikP.Analyzers.AsyncMethodAnalyzer.E522C155-0DAB-4279-946A-DD03A34258F4" Version="0.3.17" Language="en-US" Publisher="MalikP. (Peter Malik)"/>
         <DisplayName>MalikP. Async Method Analyzer (VS 2017)</DisplayName>
         <Description xml:space="preserve">This is a diagnostic extension for the .NET Compiler Platform ("Roslyn") to analyze asynchronous methods. </Description>
         <MoreInfo>https://github.com/peterM/Roslyn-Analyzers</MoreInfo>

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer15/MalikP.Analyzers.AsyncMethodAnalyzer15.csproj
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer15/MalikP.Analyzers.AsyncMethodAnalyzer15.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\AbstractCodefixProvider.cs" Link="CodeFixes\AbstractCodefixProvider.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\AbstractDocumentCodefixProvider.cs" Link="CodeFixes\AbstractDocumentCodefixProvider.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\AbstractSolutionCodefixProvider.cs" Link="CodeFixes\AbstractSolutionCodefixProvider.cs" />
+    <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\Specific\AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs" Link="CodeFixes\Specific\AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\Specific\AddMissingAsyncSuffix_Declaration_CodeFixProvider.cs" Link="CodeFixes\Specific\AddMissingAsyncSuffix_Declaration_CodeFixProvider.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\Specific\AddMissingAsyncSuffix_Invocation_CodeFixProvider.cs" Link="CodeFixes\Specific\AddMissingAsyncSuffix_Invocation_CodeFixProvider.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\Specific\AddMissingCancellationTokenParameterAndUseScoped_Invocation_CodeFixProvider.cs" Link="CodeFixes\Specific\AddMissingCancellationTokenParameterAndUseScoped_Invocation_CodeFixProvider.cs" />
@@ -70,6 +71,7 @@
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\Specific\RenameCancellationTokenParameterCodeFixProvider.cs" Link="CodeFixes\Specific\RenameCancellationTokenParameterCodeFixProvider.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\CodeFixes\Specific\ReorderCancellationTokenParameterCodeFixProvider.cs" Link="CodeFixes\Specific\ReorderCancellationTokenParameterCodeFixProvider.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\Common\SymbolExtensions.cs" Link="Common\SymbolExtensions.cs" />
+    <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\Models\SyntaxNodeReplacementPair.cs" Link="Models\SyntaxNodeReplacementPair.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\Resources.Designer.cs" Link="Resources.Designer.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\Rules\AbstractDiagnosticRuleDescriptor.cs" Link="Rules\AbstractDiagnosticRuleDescriptor.cs" />
     <Compile Include="..\MalikP.Analyzers.AsyncMethodAnalyzer16\Rules\Design\CancellationTokenParameterReusePossibility_Task_Invocation_Rule.cs" Link="Rules\Design\CancellationTokenParameterReusePossibility_Task_Invocation_Rule.cs" />
@@ -107,6 +109,7 @@
     <Folder Include="Analyzers\Specific\Design\" />
     <Folder Include="CodeFixes\Specific\" />
     <Folder Include="Common\" />
+    <Folder Include="Models\" />
     <Folder Include="Rules\Design\" />
     <Folder Include="Rules\Naming\" />
   </ItemGroup>

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer15/MalikP.Analyzers.AsyncMethodAnalyzer15.csproj
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer15/MalikP.Analyzers.AsyncMethodAnalyzer15.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>MalikP.Analyzers.AsyncMethodAnalyzer_VS2017</PackageId>
-    <PackageVersion>0.3.16.0</PackageVersion>
+    <PackageVersion>0.3.17.0</PackageVersion>
     <Authors>Peter Malik</Authors>
 	<!--<PackageLicenseUrl>https://raw.githubusercontent.com/peterM/Roslyn-Analyzers/master/LICENSE</PackageLicenseUrl>-->
 	<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
@@ -24,7 +24,7 @@
     <PackageTags>Async, analyzers</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <AssemblyName>MalikP.Analyzers.AsyncMethodAnalyzer15</AssemblyName>
-    <Version>0.3.16</Version>
+    <Version>0.3.17</Version>
     <Company>MalikP.</Company>
     <Product>Asynchronous Method Analyzer (VS2017)</Product>
     <RootNamespace>MalikP.Analyzers.AsyncMethodAnalyzer</RootNamespace>

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16.Vsix/source.extension.vsixmanifest
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="MalikP.Analyzers.AsyncMethodAnalyzer.88168c91-88a1-4722-aae0-c44043b7a9f6" Version="0.3.16" Language="en-US" Publisher="MalikP. (Peter Malik)"/>
+        <Identity Id="MalikP.Analyzers.AsyncMethodAnalyzer.88168c91-88a1-4722-aae0-c44043b7a9f6" Version="0.3.17" Language="en-US" Publisher="MalikP. (Peter Malik)"/>
         <DisplayName>MalikP. Async Method Analyzer (VS 2019)</DisplayName>
         <Description xml:space="preserve">This is a diagnostic extension for the .NET Compiler Platform ("Roslyn") to analyze asynchronous methods. </Description>
         <MoreInfo>https://github.com/peterM/Roslyn-Analyzers</MoreInfo>

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Analyzers/Specific/Naming/AsyncMethodNameSuffix_Task_Declaration_Analyzer.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Analyzers/Specific/Naming/AsyncMethodNameSuffix_Task_Declaration_Analyzer.cs
@@ -25,7 +25,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-
 using MalikP.Analyzers.AsyncMethodAnalyzer.Rules.Naming;
 
 using Microsoft.CodeAnalysis;

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
@@ -1,0 +1,140 @@
+﻿// MIT License
+//
+// Copyright (c) 2019 Peter Malik.
+// 
+// File: AddMissingCancellationTokenParameterAndUseScoped_Invocation_CodeFixProvider.cs 
+// Company: MalikP.
+//
+// Repository: https://github.com/peterM/Roslyn-Analyzers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using MalikP.Analyzers.AsyncMethodAnalyzer.Models;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace MalikP.Analyzers.AsyncMethodAnalyzer.CodeFixes.Specific
+{
+    public abstract class AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider : AbstractSolutionCodefixProvider<InvocationExpressionSyntax>
+    {
+        private const string _identifierName = "cancellationToken";
+
+        protected override async Task<Solution> ChangedSolutionHandlerAsync(Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken)
+        {
+            SyntaxNodeReplacementPair invocation = await ConstructInvocationPairAsync(document, syntaxDeclaration, cancellationToken)
+                .ConfigureAwait(false);
+
+            SyntaxNodeReplacementPair declaration = await ConstructDeclarationPairAsync(document, syntaxDeclaration, cancellationToken)
+                .ConfigureAwait(false);
+
+            Solution solution = document.Project.Solution;
+            return await UpdateDocumentsAsync(solution, invocation, declaration, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected abstract Task<SyntaxNodeReplacementPair> ConstructInvocationPairAsync(Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken);
+
+        private async Task<Solution> UpdateDocumentsAsync(Solution solution, SyntaxNodeReplacementPair invocation, SyntaxNodeReplacementPair declaration, CancellationToken cancellationToken)
+        {
+            if (AreTheSameDocuments(invocation.Document, declaration.Document))
+            {
+                try
+                {
+                    SyntaxNode root = invocation.Root.ReplaceNode(invocation.OriginalNode, invocation.ReplacementNode);
+
+                    SyntaxNode found = root.FindNode(declaration.OriginalNode.Span);
+                    root = root.ReplaceNode(found, declaration.ReplacementNode);
+
+                    solution = solution.WithDocumentSyntaxRoot(declaration.Document.Id, root);
+                }
+                catch
+                {
+                    // TODO: add loging or improve logic to be sure that exception never occure
+                }
+            }
+            else
+            {
+                solution = await ReplaceAndSimplifyNodeAsync(solution, invocation, cancellationToken)
+                    .ConfigureAwait(false);
+
+                solution = await ReplaceAndSimplifyNodeAsync(solution, declaration, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return solution;
+        }
+
+        private bool AreTheSameDocuments(Document invocationDocument, Document declarationDocument)
+        {
+            return invocationDocument.Id == declarationDocument.Id;
+        }
+
+        private async Task<Solution> ReplaceAndSimplifyNodeAsync(Solution solution, SyntaxNodeReplacementPair pair, CancellationToken cancellationToken)
+        {
+            SyntaxNode node = pair.Root.ReplaceNode(pair.OriginalNode, pair.ReplacementNode.WithAdditionalAnnotations(Simplifier.Annotation));
+
+            node = await SimplifyAsync(solution, pair.Document.Id, node, cancellationToken).ConfigureAwait(false);
+
+            return solution.WithDocumentSyntaxRoot(pair.Document.Id, node);
+        }
+
+        private async Task<SyntaxNode> SimplifyAsync(Solution solution, DocumentId documentId, SyntaxNode root, CancellationToken cancellationToken)
+        {
+            Document document = solution.GetDocument(documentId);
+
+            document = document.WithSyntaxRoot(root);
+
+            DocumentOptionSet options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+
+            document = await Simplifier.ReduceAsync(document, options, cancellationToken).ConfigureAwait(false);
+
+            return await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<SyntaxNodeReplacementPair> ConstructDeclarationPairAsync(Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken)
+        {
+            SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            ISymbol symbol = semanticModel.GetSymbolInfo(syntaxDeclaration).Symbol;
+
+            SyntaxReference declaringSyntax = symbol.DeclaringSyntaxReferences.FirstOrDefault();
+
+            MethodDeclarationSyntax methodSyntax = declaringSyntax.GetSyntax(cancellationToken) as MethodDeclarationSyntax;
+
+            SyntaxToken identifier = SyntaxFactory.Identifier(_identifierName);
+            TypeSyntax typeName = SyntaxFactory.ParseTypeName(typeof(CancellationToken).FullName);
+
+            ParameterSyntax parameter = SyntaxFactory
+                .Parameter(identifier)
+                .WithType(typeName);
+
+            MethodDeclarationSyntax updatedMethod = methodSyntax.AddParameterListParameters(parameter);
+
+            document = document.Project.Solution.GetDocument(declaringSyntax.SyntaxTree);
+
+            return new SyntaxNodeReplacementPair(document, declaringSyntax.SyntaxTree.GetRoot(), methodSyntax, updatedMethod);
+        }
+    }
+}

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2019 Peter Malik.
 // 
-// File: AddMissingCancellationTokenParameterAndUseScoped_Invocation_CodeFixProvider.cs 
+// File: AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs 
 // Company: MalikP.
 //
 // Repository: https://github.com/peterM/Roslyn-Analyzers

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
@@ -57,17 +57,7 @@ namespace MalikP.Analyzers.AsyncMethodAnalyzer.CodeFixes.Specific
 
         protected override async Task<Solution> ChangedSolutionHandlerAsync(Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken)
         {
-            ArgumentSyntax newArgument = SyntaxFactory.Argument(
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            SyntaxFactory.MemberAccessExpression(
-                                SyntaxKind.SimpleMemberAccessExpression,
-                                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("System")),
-                                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("Threading"))),
-                            SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("CancellationToken"))),
-                        SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("None"))));
+            ArgumentSyntax newArgument = CreateArgument();
 
             InvocationExpressionSyntax updatedMethodInvocation = syntaxDeclaration.AddArgumentListArguments(newArgument);
 
@@ -80,6 +70,21 @@ namespace MalikP.Analyzers.AsyncMethodAnalyzer.CodeFixes.Specific
             Solution solution = document.Project.Solution.WithDocumentSyntaxRoot(document.Id, updatedSyntaxTree);
 
             return await AddCancellationTokenToDeclaringMethod(solution, document, syntaxDeclaration, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static ArgumentSyntax CreateArgument()
+        {
+            return SyntaxFactory.Argument(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("System")),
+                                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("Threading"))),
+                            SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("CancellationToken"))),
+                        SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("None"))));
         }
 
         private async Task<Solution> AddCancellationTokenToDeclaringMethod(Solution solution, Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken)

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
@@ -26,23 +26,21 @@
 // SOFTWARE.
 
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using MalikP.Analyzers.AsyncMethodAnalyzer.Models;
 using MalikP.Analyzers.AsyncMethodAnalyzer.Rules.Design;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Simplification;
 
 namespace MalikP.Analyzers.AsyncMethodAnalyzer.CodeFixes.Specific
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddMissingCancellationTokenParameter_Invocation_CodeFixProvider)), Shared]
-    public sealed class AddMissingCancellationTokenParameter_Invocation_CodeFixProvider : AbstractSolutionCodefixProvider<InvocationExpressionSyntax>
+    public sealed class AddMissingCancellationTokenParameter_Invocation_CodeFixProvider : AbstractAddMissingCancellationTokenParameter_Invocation_CodeFixProvider
     {
         private const string _identifierName = "cancellationToken";
 
@@ -55,56 +53,13 @@ namespace MalikP.Analyzers.AsyncMethodAnalyzer.CodeFixes.Specific
                 MissingCancellationTokenParameter_Void_Invocation_Rule.DiagnosticId
             };
 
-        protected override async Task<Solution> ChangedSolutionHandlerAsync(Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken)
+        protected override async Task<SyntaxNodeReplacementPair> ConstructInvocationPairAsync(Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken)
         {
             ArgumentSyntax newArgument = CreateArgument();
-
             InvocationExpressionSyntax updatedMethodInvocation = syntaxDeclaration.AddArgumentListArguments(newArgument);
 
-            SyntaxTree syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-
-            SyntaxNode updatedSyntaxTree = syntaxTree
-                .GetRoot()
-                .ReplaceNode(syntaxDeclaration, updatedMethodInvocation);
-
-            Solution solution = document.Project.Solution.WithDocumentSyntaxRoot(document.Id, updatedSyntaxTree);
-
-            return await AddCancellationTokenToDeclaringMethod(solution, document, syntaxDeclaration, cancellationToken).ConfigureAwait(false);
-        }
-
-        private async Task<Solution> AddCancellationTokenToDeclaringMethod(Solution solution, Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken)
-        {
-            SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            ISymbol symbol = semanticModel.GetSymbolInfo(syntaxDeclaration).Symbol;
-
-            SyntaxReference declaringSyntax = symbol.DeclaringSyntaxReferences.FirstOrDefault();
-
-            MethodDeclarationSyntax methodSyntax = declaringSyntax?.GetSyntax(cancellationToken) as MethodDeclarationSyntax;
-
-            SyntaxToken identifier = SyntaxFactory.Identifier(_identifierName);
-            TypeSyntax typeName = SyntaxFactory.ParseTypeName(typeof(CancellationToken).FullName);
-
-            ParameterSyntax parameter = SyntaxFactory
-                .Parameter(identifier)
-                .WithType(typeName)
-                .WithAdditionalAnnotations(Simplifier.Annotation);
-
-            MethodDeclarationSyntax updatedMethod = methodSyntax.AddParameterListParameters(parameter);
-
-            SyntaxNode updatedSyntaxTree = declaringSyntax.SyntaxTree
-                .GetRoot()
-                .ReplaceNode(methodSyntax, updatedMethod);
-
-            document = document.Project.Solution.GetDocument(declaringSyntax.SyntaxTree);
-            document = document.WithSyntaxRoot(updatedSyntaxTree);
-
-            DocumentOptionSet options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-
-            document = await Simplifier.ReduceAsync(document, options, cancellationToken).ConfigureAwait(false);
-
-            updatedSyntaxTree = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            return solution.WithDocumentSyntaxRoot(document.Id, updatedSyntaxTree);
+            SyntaxNode root = await GetRootAsync(document, cancellationToken).ConfigureAwait(false);
+            return new SyntaxNodeReplacementPair(document, root, syntaxDeclaration, updatedMethodInvocation);
         }
 
         private ArgumentSyntax CreateArgument()

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/CodeFixes/Specific/AddMissingCancellationTokenParameter_Invocation_CodeFixProvider.cs
@@ -72,21 +72,6 @@ namespace MalikP.Analyzers.AsyncMethodAnalyzer.CodeFixes.Specific
             return await AddCancellationTokenToDeclaringMethod(solution, document, syntaxDeclaration, cancellationToken).ConfigureAwait(false);
         }
 
-        private static ArgumentSyntax CreateArgument()
-        {
-            return SyntaxFactory.Argument(
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            SyntaxFactory.MemberAccessExpression(
-                                SyntaxKind.SimpleMemberAccessExpression,
-                                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("System")),
-                                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("Threading"))),
-                            SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("CancellationToken"))),
-                        SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("None"))));
-        }
-
         private async Task<Solution> AddCancellationTokenToDeclaringMethod(Solution solution, Document document, InvocationExpressionSyntax syntaxDeclaration, CancellationToken cancellationToken)
         {
             SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
@@ -120,6 +105,21 @@ namespace MalikP.Analyzers.AsyncMethodAnalyzer.CodeFixes.Specific
             updatedSyntaxTree = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             return solution.WithDocumentSyntaxRoot(document.Id, updatedSyntaxTree);
+        }
+
+        private ArgumentSyntax CreateArgument()
+        {
+            return SyntaxFactory.Argument(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("System")),
+                                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("Threading"))),
+                            SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("CancellationToken"))),
+                        SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("None"))));
         }
     }
 }

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Common/SymbolExtensions.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Common/SymbolExtensions.cs
@@ -1,4 +1,31 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// MIT License
+//
+// Copyright (c) 2019 Peter Malik.
+// 
+// File: SymbolExtensions.cs 
+// Company: MalikP.
+//
+// Repository: https://github.com/peterM/Roslyn-Analyzers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.CodeAnalysis;
 
 namespace MalikP.Analyzers.AsyncMethodAnalyzer.Common
 {

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/MalikP.Analyzers.AsyncMethodAnalyzer16.csproj
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/MalikP.Analyzers.AsyncMethodAnalyzer16.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>MalikP.Analyzers.AsyncMethodAnalyzer</PackageId>
-    <PackageVersion>0.3.16.0</PackageVersion>
+    <PackageVersion>0.3.17.0</PackageVersion>
     <Authors>Peter Malik</Authors>
     <!--<PackageLicenseUrl>https://raw.githubusercontent.com/peterM/Roslyn-Analyzers/master/LICENSE</PackageLicenseUrl>-->
 	<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
@@ -24,7 +24,7 @@
     <PackageTags>Async, analyzers</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <AssemblyName>MalikP.Analyzers.AsyncMethodAnalyzer16</AssemblyName>
-    <Version>0.3.16</Version>
+    <Version>0.3.17</Version>
     <Company>MalikP.</Company>
     <Product>Asynchronous Method Analyzer (VS2019)</Product>
     <RootNamespace>MalikP.Analyzers.AsyncMethodAnalyzer</RootNamespace>

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Models/SyntaxNodeReplacementPair.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Models/SyntaxNodeReplacementPair.cs
@@ -2,7 +2,7 @@
 
 namespace MalikP.Analyzers.AsyncMethodAnalyzer.Models
 {
-    internal class SyntaxNodeReplacementPair
+    public class SyntaxNodeReplacementPair
     {
         public SyntaxNodeReplacementPair(Document document, SyntaxNode root, SyntaxNode originalNode, SyntaxNode replacementNode)
         {

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Models/SyntaxNodeReplacementPair.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Models/SyntaxNodeReplacementPair.cs
@@ -1,4 +1,31 @@
-﻿using Microsoft.CodeAnalysis;
+﻿// MIT License
+//
+// Copyright (c) 2019 Peter Malik.
+// 
+// File: SyntaxNodeReplacementPair.cs 
+// Company: MalikP.
+//
+// Repository: https://github.com/peterM/Roslyn-Analyzers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.CodeAnalysis;
 
 namespace MalikP.Analyzers.AsyncMethodAnalyzer.Models
 {

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Models/SyntaxNodeReplacementPair.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Models/SyntaxNodeReplacementPair.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace MalikP.Analyzers.AsyncMethodAnalyzer.Models
+{
+    internal class SyntaxNodeReplacementPair
+    {
+        public SyntaxNodeReplacementPair(Document document, SyntaxNode root, SyntaxNode originalNode, SyntaxNode replacementNode)
+        {
+            Document = document;
+            OriginalNode = originalNode;
+            ReplacementNode = replacementNode;
+            Root = root;
+        }
+
+        public Document Document { get; }
+        public SyntaxNode OriginalNode { get; }
+        public SyntaxNode ReplacementNode { get; }
+        public SyntaxNode Root { get; }
+    }
+}

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Resources.Designer.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace MalikP.Analyzers.AsyncMethodAnalyzer {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace MalikP.Analyzers.AsyncMethodAnalyzer {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MalikP.Analyzers.AsyncMethodAnalyzer.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MalikP.Analyzers.AsyncMethodAnalyzer.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Resources.Designer.cs
+++ b/src/Analyzers/AsyncMethodAnalyzer/MalikP.Analyzers.AsyncMethodAnalyzer16/Resources.Designer.cs
@@ -8,10 +8,12 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace MalikP.Analyzers.AsyncMethodAnalyzer {
+namespace MalikP.Analyzers.AsyncMethodAnalyzer
+{
     using System;
-    
-    
+    using System.Reflection;
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,366 +24,446 @@ namespace MalikP.Analyzers.AsyncMethodAnalyzer {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
-        
+    internal class Resources
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal Resources()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MalikP.Analyzers.AsyncMethodAnalyzer.Resources", typeof(Resources).Assembly);
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MalikP.Analyzers.AsyncMethodAnalyzer.Resources", typeof(Resources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos; or &apos;Task&lt;T&gt;&apos; should contain &apos;CancellationToken&apos; parameter. Here is possibility to add &apos;CancellationToken&apos; from scope..
         /// </summary>
-        internal static string CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_Description {
-            get {
+        internal static string CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method &apos;{0}&apos; missing &apos;CancellationToken&apos; parameter. Add and use from scope.
         /// </summary>
-        internal static string CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_MessageFormat {
-            get {
+        internal static string CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_MessageFormat" +
                         "", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Add and use scoped &apos;CancellationToken&apos; in &apos;Task&apos;, &apos;Task&lt;T&gt;&apos; methods (Invocation).
         /// </summary>
-        internal static string CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_Title {
-            get {
+        internal static string CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("CancellationTokenParameterReusePossibility_Task_Invocation_Analyzer_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method &apos;{0}&apos; missing &apos;CancellationToken&apos; parameter. Here is possibility to add &apos;CancellationToken&apos; from scope..
         /// </summary>
-        internal static string CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_Description {
-            get {
+        internal static string CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method &apos;{0}&apos; missing &apos;CancellationToken&apos; parameter. Add and use from scope.
         /// </summary>
-        internal static string CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_MessageFormat {
-            get {
+        internal static string CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_MessageFormat" +
                         "", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Add and use scoped &apos;CancellationToken&apos; in &apos;async void&apos; methods (Invocation).
         /// </summary>
-        internal static string CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_Title {
-            get {
+        internal static string CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("CancellationTokenParameterReusePossibility_Void_Invocation_Analyzer_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos; or &apos;Task&lt;T&gt;&apos; should have &apos;Async&apos; suffix..
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Task_Declaration_Rule_Description {
-            get {
+        internal static string MethodMissingAsyncSuffix_Task_Declaration_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Task_Declaration_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method &apos;{0}&apos; missing &apos;Async&apos; suffix.
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Task_Declaration_Rule_MessageFormat {
-            get {
+        internal static string MethodMissingAsyncSuffix_Task_Declaration_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Task_Declaration_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos;, &apos;Task&lt;T&gt;&apos; missing &apos;Async&apos; suffix.
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Task_Declaration_Rule_Title {
-            get {
+        internal static string MethodMissingAsyncSuffix_Task_Declaration_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Task_Declaration_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos; or &apos;Task&lt;T&gt;&apos; should have &apos;Async&apos; suffix..
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Task_Invocation_Rule_Description {
-            get {
+        internal static string MethodMissingAsyncSuffix_Task_Invocation_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Task_Invocation_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method &apos;{0}&apos; missing &apos;Async&apos; suffix.
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Task_Invocation_Rule_MessageFormat {
-            get {
+        internal static string MethodMissingAsyncSuffix_Task_Invocation_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Task_Invocation_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos;, &apos;Task&lt;T&gt;&apos; missing &apos;Async&apos; suffix (Invocation).
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Task_Invocation_Rule_Title {
-            get {
+        internal static string MethodMissingAsyncSuffix_Task_Invocation_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Task_Invocation_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method name should end with &apos;Async&apos; suffix..
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Void_Declaration_Rule_Description {
-            get {
+        internal static string MethodMissingAsyncSuffix_Void_Declaration_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Void_Declaration_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method &apos;{0}&apos; missing &apos;Async&apos; suffix.
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Void_Declaration_Rule_MessageFormat {
-            get {
+        internal static string MethodMissingAsyncSuffix_Void_Declaration_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Void_Declaration_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method missing &apos;Async&apos; suffix.
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Void_Declaration_Rule_Title {
-            get {
+        internal static string MethodMissingAsyncSuffix_Void_Declaration_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Void_Declaration_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method name should end with &apos;Async&apos; suffix..
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Void_Invocation_Rule_Description {
-            get {
+        internal static string MethodMissingAsyncSuffix_Void_Invocation_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Void_Invocation_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method &apos;{0}&apos; missing &apos;Async&apos; suffix.
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Void_Invocation_Rule_MessageFormat {
-            get {
+        internal static string MethodMissingAsyncSuffix_Void_Invocation_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Void_Invocation_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method missing &apos;Async&apos; suffix (Invocation).
         /// </summary>
-        internal static string MethodMissingAsyncSuffix_Void_Invocation_Rule_Title {
-            get {
+        internal static string MethodMissingAsyncSuffix_Void_Invocation_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("MethodMissingAsyncSuffix_Void_Invocation_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos; or &apos;Task&lt;T&gt;&apos; should contain &apos;CancellationToken&apos; parameter..
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Task_Declaration_Rule_Description {
-            get {
+        internal static string MissingCancellationTokenParameter_Task_Declaration_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Task_Declaration_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method &apos;{0}&apos; missing &apos;CancellationToken&apos; parameter.
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Task_Declaration_Rule_MessageFormat {
-            get {
+        internal static string MissingCancellationTokenParameter_Task_Declaration_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Task_Declaration_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos; or &apos;Task&lt;T&gt;&apos; missing &apos;CancellationToken&apos; parameter.
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Task_Declaration_Rule_Title {
-            get {
+        internal static string MissingCancellationTokenParameter_Task_Declaration_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Task_Declaration_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos; or &apos;Task&lt;T&gt;&apos; should contain &apos;CancellationToken&apos; parameter..
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Task_Invocation_Rule_Description {
-            get {
+        internal static string MissingCancellationTokenParameter_Task_Invocation_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Task_Invocation_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method &apos;{0}&apos; missing &apos;CancellationToken&apos; parameter.
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Task_Invocation_Rule_MessageFormat {
-            get {
+        internal static string MissingCancellationTokenParameter_Task_Invocation_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Task_Invocation_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Method returning &apos;Task&apos; or &apos;Task&lt;T&gt;&apos; missing &apos;CancellationToken&apos; parameter (Invocation).
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Task_Invocation_Rule_Title {
-            get {
+        internal static string MissingCancellationTokenParameter_Task_Invocation_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Task_Invocation_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method should contain &apos;CancellationToken&apos; parameter..
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Void_Declaration_Rule_Description {
-            get {
+        internal static string MissingCancellationTokenParameter_Void_Declaration_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Void_Declaration_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method &apos;{0}&apos; missing &apos;CancellationToken&apos; parameter.
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Void_Declaration_Rule_MessageFormat {
-            get {
+        internal static string MissingCancellationTokenParameter_Void_Declaration_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Void_Declaration_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method missing &apos;CancellationToken&apos; parameter.
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Void_Declaration_Rule_Title {
-            get {
+        internal static string MissingCancellationTokenParameter_Void_Declaration_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Void_Declaration_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method should contain &apos;CancellationToken&apos; parameter..
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Void_Invocation_Rule_Description {
-            get {
+        internal static string MissingCancellationTokenParameter_Void_Invocation_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Void_Invocation_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method &apos;{0}&apos; missing &apos;CancellationToken&apos; parameter.
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Void_Invocation_Rule_MessageFormat {
-            get {
+        internal static string MissingCancellationTokenParameter_Void_Invocation_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Void_Invocation_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Asynchronous &apos;void&apos; method missing &apos;CancellationToken&apos; parameter (Invocation).
         /// </summary>
-        internal static string MissingCancellationTokenParameter_Void_Invocation_Rule_Title {
-            get {
+        internal static string MissingCancellationTokenParameter_Void_Invocation_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingCancellationTokenParameter_Void_Invocation_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;CancellationToken&apos; should be named &apos;cancellationToken&apos;..
         /// </summary>
-        internal static string WrongCancellationTokenMethodParameterName_Declaration_Rule_Description {
-            get {
+        internal static string WrongCancellationTokenMethodParameterName_Declaration_Rule_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("WrongCancellationTokenMethodParameterName_Declaration_Rule_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to CancellationToken parameter &apos;{0}&apos; name differs from &apos;cancellationToken&apos;.
         /// </summary>
-        internal static string WrongCancellationTokenMethodParameterName_Declaration_Rule_MessageFormat {
-            get {
+        internal static string WrongCancellationTokenMethodParameterName_Declaration_Rule_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("WrongCancellationTokenMethodParameterName_Declaration_Rule_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;CancellationToken&apos; has wrong name.
         /// </summary>
-        internal static string WrongCancellationTokenMethodParameterName_Declaration_Rule_Title {
-            get {
+        internal static string WrongCancellationTokenMethodParameterName_Declaration_Rule_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("WrongCancellationTokenMethodParameterName_Declaration_Rule_Title", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Position of &apos;CancellationToken&apos; parameter is wrong. Parameter &apos;CancellationToken&apos; should be last method parameter..
         /// </summary>
-        internal static string WrongCancellationTokenMethodParameterPositionRule_Declaration_Description {
-            get {
+        internal static string WrongCancellationTokenMethodParameterPositionRule_Declaration_Description
+        {
+            get
+            {
                 return ResourceManager.GetString("WrongCancellationTokenMethodParameterPositionRule_Declaration_Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; position is wrong.
         /// </summary>
-        internal static string WrongCancellationTokenMethodParameterPositionRule_Declaration_MessageFormat {
-            get {
+        internal static string WrongCancellationTokenMethodParameterPositionRule_Declaration_MessageFormat
+        {
+            get
+            {
                 return ResourceManager.GetString("WrongCancellationTokenMethodParameterPositionRule_Declaration_MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Reorder &apos;CancellationToken&apos; as last.
         /// </summary>
-        internal static string WrongCancellationTokenMethodParameterPositionRule_Declaration_Title {
-            get {
+        internal static string WrongCancellationTokenMethodParameterPositionRule_Declaration_Title
+        {
+            get
+            {
                 return ResourceManager.GetString("WrongCancellationTokenMethodParameterPositionRule_Declaration_Title", resourceCulture);
             }
         }

--- a/src/TestProjects/AsyncMethodAnalyzer.TestProject/AnalyzersTestProject/Class1.cs
+++ b/src/TestProjects/AsyncMethodAnalyzer.TestProject/AnalyzersTestProject/Class1.cs
@@ -57,5 +57,15 @@ namespace AnalyzersTestProject
         {
             return CallDelay();
         }
+
+        public async void MyVoidMethod()
+        {
+            await Task.Delay(1);
+        }
+
+        public void CallVoid(CancellationToken ca)
+        {
+            MyVoidMethod();
+        }
     }
 }

--- a/src/TestProjects/AsyncMethodAnalyzer.TestProject/AnalyzersTestProject/Class1.cs
+++ b/src/TestProjects/AsyncMethodAnalyzer.TestProject/AnalyzersTestProject/Class1.cs
@@ -47,5 +47,15 @@ namespace AnalyzersTestProject
         {
             MXXddd(CancellationToken.None, 1);
         }
+
+        public Task CallDelay()
+        {
+            return Task.Delay(1);
+        }
+
+        public Task CallAsyncMethod(CancellationToken cancellationToken)
+        {
+            return CallDelay();
+        }
     }
 }


### PR DESCRIPTION
Fix problem when method `invocation` and `declaration` are in the same document and invocation node is not updated. 